### PR TITLE
Change System.GPU to Control.Parallel and more...

### DIFF
--- a/OpenCL.cabal
+++ b/OpenCL.cabal
@@ -36,32 +36,35 @@ Library
   ghc-options: -Wall
   Build-Depends: base >=4.0 && < 5, bytestring -any, mtl==2.0.*
   Exposed-Modules: 
-    System.GPU.OpenCL
-    System.GPU.OpenCL.Query
-    System.GPU.OpenCL.Context
-    System.GPU.OpenCL.CommandQueue
-    System.GPU.OpenCL.Memory
-    System.GPU.OpenCL.Event
-    System.GPU.OpenCL.Program
+    Control.Parallel.OpenCL
+    Control.Parallel.OpenCL.Query
+    Control.Parallel.OpenCL.Context
+    Control.Parallel.OpenCL.CommandQueue
+    Control.Parallel.OpenCL.Memory
+    Control.Parallel.OpenCL.Event
+    Control.Parallel.OpenCL.Program
   Other-Modules: 
-    System.GPU.OpenCL.Types
+    Control.Parallel.OpenCL.Types
 
-  
+
   if os(darwin)
-    cpp-options: "-U__BLOCKS__"
-  
+    cpp-options: -I/System/Library/Frameworks/OpenCL.framework/Headers
+  else
+    cpp-options: -Iinclude
+
   if os(windows)
       cpp-options: "-DCALLCONV=stdcall"
   else
       cpp-options: "-DCALLCONV=ccall"
 
-  cpp-options: -Iinclude
 
 Test-suite tests
   type:         exitcode-stdio-1.0
   main-is:      test-opencl.hs
   hs-Source-Dirs: src/test
   ghc-options:    -Wall
+  frameworks:     OpenCL
+  -- Remove the following line to build on OSX:
   extra-libraries: OpenCL
   build-depends: base >=4.0 && < 5, QuickCheck==2.4.0.*, OpenCL
 

--- a/examples/example01.hs
+++ b/examples/example01.hs
@@ -29,7 +29,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
-import System.GPU.OpenCL
+import Control.Parallel.OpenCL
 import Foreign( castPtr, nullPtr, sizeOf )
 import Foreign.C.Types( CFloat )
 import Foreign.Marshal.Array( newArray, peekArray )

--- a/examples/example02.hs
+++ b/examples/example02.hs
@@ -29,7 +29,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
-import System.GPU.OpenCL  
+import Control.Parallel.OpenCL  
 import Foreign( castPtr, nullPtr, sizeOf )
 import Foreign.C.Types( CFloat )
 import Foreign.Marshal.Array( peekArray, withArray )

--- a/examples/example03.hs
+++ b/examples/example03.hs
@@ -29,7 +29,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
-import System.GPU.OpenCL  
+import Control.Parallel.OpenCL  
 import Foreign( castPtr, nullPtr, sizeOf )
 import Foreign.C.Types( CFloat )
 import Foreign.Marshal.Array( newArray, peekArray )

--- a/examples/example04.hs
+++ b/examples/example04.hs
@@ -29,7 +29,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
-import System.GPU.OpenCL
+import Control.Parallel.OpenCL
 import Foreign( castPtr, nullPtr, sizeOf )
 import Foreign.C.Types( CFloat )
 import Foreign.Marshal.Array( newArray, peekArray )

--- a/examples/example05.hs
+++ b/examples/example05.hs
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 import qualified Control.Exception as Ex( catch )
-import System.GPU.OpenCL
+import Control.Parallel.OpenCL
 import Foreign( castPtr, nullPtr, sizeOf )
 import Foreign.C.Types( CDouble )
 import Foreign.Marshal.Array( newArray, peekArray )

--- a/src/Control/Parallel/OpenCL.hs
+++ b/src/Control/Parallel/OpenCL.hs
@@ -29,27 +29,27 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
-module System.GPU.OpenCL( 
+module Control.Parallel.OpenCL( 
   -- * Basic Types
   CLError(..), CLint, CLuint, CLulong,
   -- * Modules
-  module System.GPU.OpenCL.Query,
-  module System.GPU.OpenCL.Context,
-  module System.GPU.OpenCL.CommandQueue, 
-  module System.GPU.OpenCL.Memory,
-  module System.GPU.OpenCL.Event,
-  module System.GPU.OpenCL.Program
+  module Control.Parallel.OpenCL.Query,
+  module Control.Parallel.OpenCL.Context,
+  module Control.Parallel.OpenCL.CommandQueue, 
+  module Control.Parallel.OpenCL.Memory,
+  module Control.Parallel.OpenCL.Event,
+  module Control.Parallel.OpenCL.Program
   )
        where
 
 -- -----------------------------------------------------------------------------
-import System.GPU.OpenCL.Query
-import System.GPU.OpenCL.Context
-import System.GPU.OpenCL.CommandQueue
-import System.GPU.OpenCL.Memory
-import System.GPU.OpenCL.Event
-import System.GPU.OpenCL.Program
-import System.GPU.OpenCL.Types( 
+import Control.Parallel.OpenCL.Query
+import Control.Parallel.OpenCL.Context
+import Control.Parallel.OpenCL.CommandQueue
+import Control.Parallel.OpenCL.Memory
+import Control.Parallel.OpenCL.Event
+import Control.Parallel.OpenCL.Program
+import Control.Parallel.OpenCL.Types( 
   CLError(..), CLint, CLuint, CLulong )
 
 -- -----------------------------------------------------------------------------

--- a/src/Control/Parallel/OpenCL/CommandQueue.chs
+++ b/src/Control/Parallel/OpenCL/CommandQueue.chs
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 {-# LANGUAGE ForeignFunctionInterface, ScopedTypeVariables, CPP #-}
-module System.GPU.OpenCL.CommandQueue(
+module Control.Parallel.OpenCL.CommandQueue(
   -- * Types
   CLCommandQueue, CLCommandQueueProperty(..), 
   -- * Command Queue Functions
@@ -50,14 +50,18 @@ module System.GPU.OpenCL.CommandQueue(
 -- -----------------------------------------------------------------------------
 import Foreign
 import Foreign.C.Types
-import System.GPU.OpenCL.Types( 
+import Control.Parallel.OpenCL.Types( 
   CLint, CLbool, CLuint, CLCommandQueueProperty_, CLCommandQueueInfo_, 
   CLCommandQueue, CLDeviceID, CLContext, CLCommandQueueProperty(..), 
   CLEvent, CLMem, CLKernel,
   whenSuccess, wrapCheckSuccess, wrapPError, wrapGetInfo, getCLValue, 
   bitmaskToCommandQueueProperties, bitmaskFromFlags )
 
+#ifdef __APPLE__
+#include <cl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 -- -----------------------------------------------------------------------------
 foreign import CALLCONV "clCreateCommandQueue" raw_clCreateCommandQueue :: 

--- a/src/Control/Parallel/OpenCL/Context.chs
+++ b/src/Control/Parallel/OpenCL/Context.chs
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 {-# LANGUAGE ForeignFunctionInterface, ScopedTypeVariables, CPP #-}
-module System.GPU.OpenCL.Context(
+module Control.Parallel.OpenCL.Context(
   -- * Types
   CLContext,
   -- * Context Functions
@@ -45,12 +45,16 @@ import Foreign(
 import Foreign.C.Types( CSize )
 import Foreign.C.String( CString, peekCString )
 import Foreign.Storable( sizeOf )
-import System.GPU.OpenCL.Types( 
+import Control.Parallel.OpenCL.Types( 
   CLuint, CLint, CLDeviceType_, CLContextInfo_, CLContextProperty_, CLDeviceID, 
   CLContext, CLDeviceType, bitmaskFromFlags, getCLValue,
   whenSuccess, wrapCheckSuccess, wrapPError, wrapGetInfo )
 
+#ifdef __APPLE__
+#include <cl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 -- -----------------------------------------------------------------------------
 type ContextCallback = CString -> Ptr () -> CSize -> Ptr () -> IO ()

--- a/src/Control/Parallel/OpenCL/Event.chs
+++ b/src/Control/Parallel/OpenCL/Event.chs
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 {-# LANGUAGE ForeignFunctionInterface, ScopedTypeVariables, CPP #-}
-module System.GPU.OpenCL.Event(  
+module Control.Parallel.OpenCL.Event(  
   -- * Types
   CLEvent, CLCommandType(..), CLProfilingInfo(..), CLCommandExecutionStatus(..),
   -- * Functions
@@ -42,13 +42,17 @@ module System.GPU.OpenCL.Event(
 -- -----------------------------------------------------------------------------
 import Foreign
 import Foreign.C.Types
-import System.GPU.OpenCL.Types( 
+import Control.Parallel.OpenCL.Types( 
   CLEvent, CLint, CLuint, CLulong, CLEventInfo_, CLProfilingInfo_,
   CLCommandQueue, CLCommandType(..), CLCommandType_, 
   CLCommandExecutionStatus(..), CLProfilingInfo(..), getCommandExecutionStatus, 
   getCLValue, getEnumCL, wrapCheckSuccess, wrapGetInfo )
 
+#ifdef __APPLE__
+#include <cl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 -- -----------------------------------------------------------------------------
 foreign import CALLCONV "clWaitForEvents" raw_clWaitForEvents :: 

--- a/src/Control/Parallel/OpenCL/Memory.chs
+++ b/src/Control/Parallel/OpenCL/Memory.chs
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 {-# LANGUAGE ForeignFunctionInterface, ScopedTypeVariables, CPP #-}
-module System.GPU.OpenCL.Memory(
+module Control.Parallel.OpenCL.Memory(
   -- * Types
   CLMem, CLSampler, CLMemFlag(..), CLMemObjectType(..), CLAddressingMode(..), 
   CLFilterMode(..),
@@ -47,7 +47,7 @@ module System.GPU.OpenCL.Memory(
 -- -----------------------------------------------------------------------------
 import Foreign
 import Foreign.C.Types
-import System.GPU.OpenCL.Types( 
+import Control.Parallel.OpenCL.Types( 
   CLMem, CLContext, CLSampler, CLint, CLuint, CLbool, CLMemFlags_,
   CLMemInfo_, CLAddressingMode_, CLFilterMode_, CLSamplerInfo_, 
   CLAddressingMode(..), CLFilterMode(..), CLMemFlag(..), CLMemObjectType_, 
@@ -55,7 +55,11 @@ import System.GPU.OpenCL.Types(
   wrapPError, wrapCheckSuccess, wrapGetInfo, getEnumCL, bitmaskFromFlags, 
   bitmaskToMemFlags, getCLValue )
 
+#ifdef __APPLE__
+#include <cl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 -- -----------------------------------------------------------------------------
 foreign import CALLCONV "clCreateBuffer" raw_clCreateBuffer :: 

--- a/src/Control/Parallel/OpenCL/Program.chs
+++ b/src/Control/Parallel/OpenCL/Program.chs
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 {-# LANGUAGE ForeignFunctionInterface, ScopedTypeVariables, CPP #-}
-module System.GPU.OpenCL.Program(  
+module Control.Parallel.OpenCL.Program(  
   -- * Types
   CLProgram, CLBuildStatus(..), CLKernel,
   -- * Program Functions
@@ -53,13 +53,17 @@ import Control.Monad( zipWithM, forM )
 import Foreign
 import Foreign.C.Types
 import Foreign.C.String( CString, withCString, peekCString )
-import System.GPU.OpenCL.Types( 
+import Control.Parallel.OpenCL.Types( 
   CLint, CLuint, CLulong, CLProgram, CLContext, CLKernel, CLDeviceID, CLError,
   CLProgramInfo_, CLBuildStatus(..), CLBuildStatus_, CLProgramBuildInfo_, 
   CLKernelInfo_, CLKernelWorkGroupInfo_, wrapCheckSuccess, 
   whenSuccess, wrapPError, wrapGetInfo, getCLValue, getEnumCL )
 
+#ifdef __APPLE__
+#include <cl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 -- -----------------------------------------------------------------------------
 type BuildCallback = CLProgram -> Ptr () -> IO ()

--- a/src/Control/Parallel/OpenCL/Query.chs
+++ b/src/Control/Parallel/OpenCL/Query.chs
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 {-# LANGUAGE ForeignFunctionInterface, ScopedTypeVariables, CPP #-}
-module System.GPU.OpenCL.Query( 
+module Control.Parallel.OpenCL.Query( 
   -- * Types
   CLPlatformInfo(..), CLPlatformID, CLDeviceID, CLDeviceType(..),
   CLDeviceFPConfig(..), CLDeviceExecCapability(..), CLDeviceLocalMemType(..),
@@ -69,7 +69,7 @@ import Foreign( Ptr, nullPtr, castPtr, alloca, allocaArray, peek, peekArray )
 import Foreign.C.String( CString, peekCString )
 import Foreign.C.Types( CSize )
 import Foreign.Storable( sizeOf )
-import System.GPU.OpenCL.Types( 
+import Control.Parallel.OpenCL.Types( 
   CLbool, CLint, CLuint, CLulong, CLPlatformInfo_, CLDeviceType_,
   CLDeviceInfo_, CLDeviceFPConfig(..), CLDeviceExecCapability(..),
   CLDeviceLocalMemType(..), CLDeviceMemCacheType(..), CLPlatformInfo(..),
@@ -87,7 +87,11 @@ foreign import CALLCONV "clGetDeviceIDs" raw_clGetDeviceIDs ::
 foreign import CALLCONV "clGetDeviceInfo" raw_clGetDeviceInfo :: 
   CLDeviceID -> CLDeviceInfo_ -> CSize -> Ptr () -> Ptr CSize -> IO CLint
 
+#ifdef __APPLE__
+#include <cl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 -- -----------------------------------------------------------------------------
 getNumPlatforms :: IO CLuint

--- a/src/Control/Parallel/OpenCL/Types.chs
+++ b/src/Control/Parallel/OpenCL/Types.chs
@@ -30,7 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 {-# LANGUAGE DeriveDataTypeable #-}
-module System.GPU.OpenCL.Types( 
+module Control.Parallel.OpenCL.Types( 
   -- * Symple CL Types
   CLbool, CLint, CLuint, CLulong, CLProgram, CLEvent, CLMem, CLPlatformID, 
   CLDeviceID, CLContext, CLCommandQueue, CLPlatformInfo_, CLDeviceType_, 
@@ -61,7 +61,11 @@ import Data.Typeable( Typeable(..) )
 import Control.Applicative( (<$>) )
 import Control.Exception( Exception(..), throwIO )
 
+#ifdef __APPLE__
+#include <cl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 -- -----------------------------------------------------------------------------
 

--- a/src/test/test-opencl.hs
+++ b/src/test/test-opencl.hs
@@ -39,7 +39,7 @@ import Test.QuickCheck.Monadic( monadicIO, assert, run )
 import Test.QuickCheck.Test( Result, Args(..), isSuccess, stdArgs )
 import Text.Printf( printf )
 import System.Exit( exitSuccess, exitFailure )
-import System.GPU.OpenCL
+import Control.Parallel.OpenCL
 
 -- -----------------------------------------------------------------------------
 clDupSource :: String


### PR DESCRIPTION
To be able to test this on osx I had to change some potentially unrelated things in OpenCL.cabal.

I left the test-suite section in, but that has to be modified to build on OSX due to a bug in Cabal where you can't put conditionals in a test-suite section:
- http://www.haskell.org/pipermail/cabal-devel/2011-March/007316.html

I tried to wrap the whole test-suite section in a conditional but that failed to parse.  I tried to use a flag and set buildable to the value of the flag but that also failed.  I'm out of ideas for how to manage that.  It really just comes down to us needing to specify extra-libraries on non-OSX platforms.  Specifying frameworks should be fine on all platforms.

I found that the included headers did not match the OSX headers and so that was causing parse errors for c2hs.  So I hardcoded the default install path for OpenCL headers on OSX.  The one thing here is that I tested on 10.6 which ships OpenCL 1.0 instead of 1.1.  It's possible my changes will not be compatible with OSX 10.7.

If we change the module names, I think we need to bump to 1.1.x due to the Package Version Policy:
http://www.haskell.org/haskellwiki/Package_versioning_policy

Thanks!
Jason
