### PR TITLE
darwin cabal tweak

### DIFF
--- a/OpenCL.cabal
+++ b/OpenCL.cabal
@@ -51,7 +51,7 @@ Library
     Frameworks:  OpenCL
 
   if os(darwin)
-    cpp-options: -DCALLCONV=ccall -I/System/Library/Frameworks/OpenCL.framework/Headers
+    cpp-options: -DCALLCONV=ccall
     cc-options: "-U__BLOCKS__"
     Frameworks:  OpenCL
 


### PR DESCRIPTION
The Frameworks option subsumes the -I cpp option for darwin builds.
