### PR TITLE
User friendly message for bad OpenCL installations...

### DIFF
--- a/src/Control/Parallel/OpenCL/Types.chs
+++ b/src/Control/Parallel/OpenCL/Types.chs
@@ -65,6 +65,7 @@ import Control.Exception( Exception(..), throwIO )
 #include <OpenCL/opencl.h>
 #else
 #include <CL/cl.h>
+#include <CL/cl_ext.h>
 #endif
 
 -- -----------------------------------------------------------------------------
@@ -115,6 +116,7 @@ type CLAddressingMode_ = {#type cl_addressing_mode#}
 -- -----------------------------------------------------------------------------
 #c
 enum CLError {
+  cL_PLATFORM_NOT_FOUND_KHR=CL_PLATFORM_NOT_FOUND_KHR,
   cL_BUILD_PROGRAM_FAILURE=CL_BUILD_PROGRAM_FAILURE,
   cL_COMPILER_NOT_AVAILABLE=CL_COMPILER_NOT_AVAILABLE,
   cL_DEVICE_NOT_AVAILABLE=CL_DEVICE_NOT_AVAILABLE,
@@ -176,6 +178,9 @@ available.
 
  * 'CL_DEVICE_NOT_FOUND', Returned if no OpenCL devices that match the specified
 devices were found.
+
+ * 'CL_PLATFORM_NOT_FOUND_khr', Returned when no .icd (platform drivers)
+ can be properly loaded.
 
  * 'CL_IMAGE_FORMAT_MISMATCH', Returned if the specified source and destination
 images are not valid image objects.


### PR DESCRIPTION
Khronos .icd extension may report error when no platform is
found. This patch essentially provides a friendly error message like:
**\* Exception: CL_PLATFORM_NOT_FOUND_KHR

Previously it was just an error code:
**\* Exception: CLError.toEnum: Cannot match -1001
