### PR TITLE
Removed clamping to LocalWorkSize 1

### DIFF
--- a/examples/example01.hs
+++ b/examples/example01.hs
@@ -64,7 +64,7 @@ main = do
   clSetKernelArgSto kernel 1 mem_out
   
   -- Execute Kernel
-  eventExec <- clEnqueueNDRangeKernel q kernel [length original] [1] []
+  eventExec <- clEnqueueNDRangeKernel q kernel [length original] [] []
   
   -- Get Result
   eventRead <- clEnqueueReadBuffer q mem_out True 0 vecSize (castPtr input) [eventExec]

--- a/examples/example02.hs
+++ b/examples/example02.hs
@@ -81,7 +81,7 @@ executeArray original ctx q krn = withArray original $ \input -> do
   eventWrite <- clEnqueueWriteBuffer q mem_in True 0 vecSize (castPtr input) []
   
   -- Execute Kernel
-  eventExec <- clEnqueueNDRangeKernel q krn [length original] [1] [eventWrite]
+  eventExec <- clEnqueueNDRangeKernel q krn [length original] [] [eventWrite]
   
   -- Get Result
   eventRead <- clEnqueueReadBuffer q mem_out True 0 vecSize (castPtr input) [eventExec]

--- a/examples/example03.hs
+++ b/examples/example03.hs
@@ -80,9 +80,9 @@ main = do
   clSetKernelArgSto kernel3 1 mem_out2
   
   -- Execute Kernels
-  eventExec1 <- clEnqueueNDRangeKernel q kernel1 [length original] [1] []
-  eventExec2 <- clEnqueueNDRangeKernel q kernel2 [length original] [1] [eventExec1]
-  eventExec3 <- clEnqueueNDRangeKernel q kernel3 [length original] [1] [eventExec1]
+  eventExec1 <- clEnqueueNDRangeKernel q kernel1 [length original] [] []
+  eventExec2 <- clEnqueueNDRangeKernel q kernel2 [length original] [] [eventExec1]
+  eventExec3 <- clEnqueueNDRangeKernel q kernel3 [length original] [] [eventExec1]
   
   -- Get Result
   eventRead <- clEnqueueReadBuffer q mem_out1 True 0 vecSize (castPtr input) [eventExec2,eventExec3]

--- a/examples/example04.hs
+++ b/examples/example04.hs
@@ -69,7 +69,7 @@ main = do
   clSetKernelArgSto kernel 1 mem_out
   
   -- Execute Kernel
-  eventExec <- clEnqueueNDRangeKernel q kernel [length original] [1] []
+  eventExec <- clEnqueueNDRangeKernel q kernel [length original] [] []
   
   -- Get Result
   eventRead <- clEnqueueReadBuffer q mem_out True 0 vecSize (castPtr input) [eventExec]

--- a/examples/example05.hs
+++ b/examples/example05.hs
@@ -73,7 +73,7 @@ main = do
   clSetKernelArgSto kernel 1 mem_out
   
   -- Execute Kernel
-  eventExec <- clEnqueueNDRangeKernel q kernel [length original] [1] []
+  eventExec <- clEnqueueNDRangeKernel q kernel [length original] [] []
   
   -- Get Result
   eventRead <- clEnqueueReadBuffer q mem_out True 0 vecSize (castPtr input) [eventExec]

--- a/examples/example06.hs
+++ b/examples/example06.hs
@@ -65,7 +65,7 @@ main = do
   clSetKernelArg kernel 2 4 nullPtr
   
   -- Execute Kernel
-  eventExec <- clEnqueueNDRangeKernel q kernel [length original] [1] []
+  eventExec <- clEnqueueNDRangeKernel q kernel [length original] [] []
   
   -- Get Result
   eventRead <- clEnqueueReadBuffer q mem_out True 0 vecSize (castPtr input) [eventExec]


### PR DESCRIPTION
The GPU card will select an appropriate value automatically. In any case, 1 is worst case and reduces performance.