### PR TITLE
Fix compilation failure on OS X El Capitan

### DIFF
--- a/OpenCL.cabal
+++ b/OpenCL.cabal
@@ -54,7 +54,7 @@ Library
     extra-libraries: OpenCL
 
   if os(darwin)
-    cpp-options: -DCALLCONV=ccall
+    cpp-options: -DCALLCONV=ccall -D__nullable= -D__nonnull=
     cc-options: "-U__BLOCKS__"
     Frameworks:  OpenCL
 


### PR DESCRIPTION
This PR fixes the compilation failure on Mac OS X El Capitan (10.11) reported at #47.
