### PR TITLE
Fix compilation error on GHC-9.0

### DIFF
--- a/src/Control/Parallel/OpenCL/Memory.chs
+++ b/src/Control/Parallel/OpenCL/Memory.chs
@@ -271,8 +271,8 @@ value.
 {#enum CLChannelType {upcaseFirstLetter} deriving(Show)#}
 
 data CLImageFormat = CLImageFormat
-                     { image_channel_order :: ! CLChannelOrder
-                     , image_channel_data_type :: ! CLChannelType }
+                     { image_channel_order :: !CLChannelOrder
+                     , image_channel_data_type :: !CLChannelType }
                      deriving( Show )
 {#pointer *cl_image_format as CLImageFormat_p -> CLImageFormat#}
 instance Storable CLImageFormat where


### PR DESCRIPTION
We need to remove spaces after `!` in the strictness annotations.
Otherwise, GHC-9.0 interprets it as an infix operator instead of a strictness annotation.
https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst
